### PR TITLE
Info about the need of some libs (to lxml) on debian like systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,13 @@ class TheGoodThings(Vows.Context):
         <p>Or to upgrade:</p>
 
         <pre><code>$ pip install -U pyvows</code></pre>
+
+        <p>Note: If you are on a Debian like system (Ubuntu) and the pyVows fails to install,
+        you may need to install these packages (as root):</p>
+
+        <pre><code># apt-get install libxslt-dev libxml2-dev</code></pre>
+
+        <p>After installing the packages, try to install pyVows again.</p>
     </div>
 </section>
 


### PR DESCRIPTION
Adding some info about how to install the required libs in order to install pyvows in debian like systems (libs required by lxml)
