### PR TITLE
Update documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,6 +895,18 @@ $ pyvows tests/
     <td>Coverage number below which coverage is considered failing. Defaults to 80.0.</td>
   </tr>
   <tr>
+    <td class="usage"><code>-r</code>, <code>--cover_report</code></td>
+    <td>Store the coverage report as the specified file</td>
+  </tr>
+  <tr>
+    <td class="usage"><code>-x</code>, <code>--xunit_output</code></td>
+    <td>Enable XUnit output</td>
+  </tr>
+  <tr>
+    <td class="usage"><code>-f</code>, <code>--xunit_file</code></td>
+    <td>Filename of the XUnit output (default: pyvows.xml)</td>
+  </tr>
+  <tr>
     <td class="usage"><code>--help</code></td>
     <td>Show help</td>
   </tr>


### PR DESCRIPTION
Hi again!

Small update to the web page with respect to the command line arguments.
- the web page contains a dash (-) with the long args but it should be an underscore (_)
- adding documentation about the coverage report and the xunit output

Best
Daniel
