### PR TITLE
Added a verbosity level 4 that causes the topics of generative tests to ...

### DIFF
--- a/pyvows/reporting.py
+++ b/pyvows/reporting.py
@@ -20,9 +20,16 @@ from pyvows.core import VowsAssertionError
 PROGRESS_SIZE = 50
 
 # verbosity levels
+V_EXTRA_VERBOSE = 4
 V_VERBOSE = 3
 V_NORMAL = 2
 V_SILENT = 1
+
+def ensure_encoded(thing, encoding='utf-8'):
+    if isinstance(thing, unicode):
+        return thing.encode(encoding)
+    else:
+        return thing
 
 class VowsDefaultReporter(object):
     honored = Fore.GREEN + Style.BRIGHT + '✓' + Fore.RESET + Style.RESET_ALL
@@ -117,8 +124,16 @@ class VowsDefaultReporter(object):
 
         for test in context['tests']:
             if test['succeeded']:
-                if self.verbosity >= V_VERBOSE:
-                    self.humanized_print(VowsDefaultReporter.honored + ' ' + test['name'])
+                honored, topic, name = map(
+                    ensure_encoded,
+                    (VowsDefaultReporter.honored, test['topic'], test['name']))
+                if self.verbosity == V_VERBOSE:
+                    self.humanized_print('%s %s' % (honored, name))
+                elif self.verbosity >= V_EXTRA_VERBOSE:
+                    if test['enumerated']:
+                        self.humanized_print('%s %s - %s' % (honored, topic, name))
+                    else:
+                        self.humanized_print('%s %s' % (honored, name))
             else:
                 self.humanized_print(VowsDefaultReporter.broken + ' ' + test['name'])
 

--- a/pyvows/runner.py
+++ b/pyvows/runner.py
@@ -136,7 +136,8 @@ class VowsParallelRunner(object):
         filename, lineno = self.file_info_for(member._original)
         result_obj = {
             'context_instance': context_instance,
-            'name': member_name if not enumerated else '%s - %s' % (str(topic), member_name),
+            'name': member_name,
+            'enumerated': enumerated,
             'result': None,
             'topic': topic,
             'error': None,


### PR DESCRIPTION
... be printed while they are no longer printed on level 3.

Topics may often be objects whose string representation is extremely long (e.g., extremely long strings), and you don’t usually want to see a several-megabyte-long string for each of your hundreds of generative tests.
