### PR TITLE
Added an optional argument --path as default for the positional argument path

### DIFF
--- a/pyvows/console.py
+++ b/pyvows/console.py
@@ -40,13 +40,12 @@ class Messages(object):
     xunit_file = 'Filename of the XUnit output (default: %(default)s).'
     no_color = 'Does not colorize the output. (default: %(default)s).'
     verbosity = 'Verbosity. Can be supplied multiple times to increase verbosity (default: -vv)'
-    path = 'Directory to look for vows recursively. If a file is passed, the file will be the target for vows. (default: %(default)r).'
+    path = 'Directory to look for vows recursively. If a file is passed, the file will be the target for vows. (default: ".").'
+    default_path = 'Default for the positional path argument. (default: ".")'
     profile = 'Prints the 10 slowest topics. (default: %(default)s).'
     profile_threshold = 'Number of seconds that the test must take to be considered a slow test. (default: %(default)s).'
 
 def __get_arguments():
-    current_dir = os.curdir
-
     parser = argparse.ArgumentParser(description='Runs pyVows.')
 
     parser.add_argument('-p', '--pattern', default='*_vows.py', help=Messages.pattern)
@@ -71,8 +70,9 @@ def __get_arguments():
 
     parser.add_argument('--version', action='version', version='%(prog)s ' + version.to_str())
     parser.add_argument('-v', action='append_const', dest='verbosity', const=1, help=Messages.verbosity)
+    parser.add_argument('--path', action='store', dest='default_path', help=Messages.default_path)
 
-    parser.add_argument('path', default=current_dir, nargs='?', help=Messages.path)
+    parser.add_argument('path', nargs='?', help=Messages.path)
 
     arguments = parser.parse_args()
 
@@ -96,7 +96,7 @@ def run(path, pattern, verbosity, progress):
 def main():
     arguments = __get_arguments()
 
-    path = arguments.path
+    path = arguments.path or arguments.default_path
     pattern = arguments.pattern
 
     if path and isfile(path):


### PR DESCRIPTION
You often need to specify a base path other than '.' in a pyVows wrapper
script. However, the user should still be able to override the path without
getting error messages that seem to contradict the usage (--help).
