### PR TITLE
Minor spelling correction

### DIFF
--- a/pyvows/reporting.py
+++ b/pyvows/reporting.py
@@ -80,7 +80,7 @@ class VowsDefaultReporter(object):
             self.honored if self.result.successful else self.broken,
             self.result.successful_tests,
             self.result.errored_tests,
-            self.result.ellapsed_time
+            self.result.elapsed_time
         )
 
         print
@@ -166,7 +166,7 @@ class VowsDefaultReporter(object):
             print ' ' + '=' * len(msg)
             print
 
-            print "       Ellapsed    Context File Path                 Context Name"
+            print "       elapsed    Context File Path                 Context Name"
             for index, topic in enumerate(topics):
                 name = self.under_split(topic['context'])
                 name = self.camel_split(name)
@@ -175,7 +175,7 @@ class VowsDefaultReporter(object):
                         Fore.BLUE, 
                         index + 1, 
                         Fore.RESET, 
-                        topic['ellapsed'], 
+                        topic['elapsed'], 
                         Style.DIM,
                         Fore.WHITE,
                         topic['path'][-MAX_PATH_SIZE:], 

--- a/pyvows/result.py
+++ b/pyvows/result.py
@@ -11,7 +11,7 @@
 class VowsResult(object):
     def __init__(self):
         self.contexts = []
-        self.ellapsed_time = 0.0
+        self.elapsed_time = 0.0
 
     @property
     def successful(self):
@@ -61,7 +61,7 @@ class VowsResult(object):
             topic_times.append({
                 'context': context['name'],
                 'path': context['filename'],
-                'ellapsed': context['topic_ellapsed']
+                'elapsed': context['topic_elapsed']
             })
 
             topic_times.extend(self.get_topic_times(context['contexts']))
@@ -69,6 +69,6 @@ class VowsResult(object):
         return topic_times
 
     def get_worst_topics(self, number=10, threshold=0.1):
-        times = [time for time in self.get_topic_times() if time['ellapsed'] > 0 and time['ellapsed'] >= threshold]
-        return list(reversed(sorted(times, key=lambda x: x['ellapsed'])))[:number]
+        times = [time for time in self.get_topic_times() if time['elapsed'] > 0 and time['elapsed'] >= threshold]
+        return list(reversed(sorted(times, key=lambda x: x['elapsed'])))[:number]
 

--- a/pyvows/runner.py
+++ b/pyvows/runner.py
@@ -38,7 +38,7 @@ class VowsParallelRunner(object):
         self.pool.join()
 
         end_time = time.time()
-        result.ellapsed_time = float(end_time - start_time)
+        result.elapsed_time = float(end_time - start_time)
         return result
 
     def run_context(self, context_col, name, context_instance):
@@ -47,7 +47,7 @@ class VowsParallelRunner(object):
     def async_run_context(self, context_col, name, context_instance, index=-1):
         context_obj = {
             'name': name,
-            'topic_ellapsed': 0,
+            'topic_elapsed': 0,
             'contexts': [],
             'tests': [],
             'filename': inspect.getsourcefile(context_instance.__class__)
@@ -69,7 +69,7 @@ class VowsParallelRunner(object):
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 topic = exc_value
                 context_instance.topic_error = (exc_type, exc_value, exc_traceback)
-            context_obj['topic_ellapsed'] = float(round(time.time() - start_time, 6))
+            context_obj['topic_elapsed'] = float(round(time.time() - start_time, 6))
         else:
             topic = context_instance._get_first_available_topic(index)
 
@@ -144,7 +144,7 @@ class VowsParallelRunner(object):
             'succeeded': False,
             'file': filename,
             'lineno': lineno,
-            'ellapsed': 0
+            'elapsed': 0
         }
 
         try:
@@ -165,7 +165,7 @@ class VowsParallelRunner(object):
             if self.vow_error_event:
                 self.vow_error_event(result_obj)
 
-        result_obj['ellapsed'] = time.time() - start_time
+        result_obj['elapsed'] = time.time() - start_time
         tests_col.append(result_obj)
 
         return result_obj

--- a/pyvows/xunit.py
+++ b/pyvows/xunit.py
@@ -34,7 +34,7 @@ class XUnitReporter(object):
             'failures': result.errored_tests,
             'ts': datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
             'hostname': socket.gethostname(),
-            'elapsed': result.ellapsed_time,
+            'elapsed': result.elapsed_time,
             'contexts': result.contexts
         }
         return result_summary

--- a/tests/xunit_reporter_vows.py
+++ b/tests/xunit_reporter_vows.py
@@ -24,7 +24,7 @@ class XUnitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 0
             result.errored_tests = 0
-            result.ellapsed_time = 0
+            result.elapsed_time = 0
             result.contexts = []
             reporter = XUnitReporter(result)
             return reporter
@@ -47,7 +47,7 @@ class XUnitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 1
             result.errored_tests = 0
-            result.ellapsed_time = 0
+            result.elapsed_time = 0
             result.contexts = [
                 {
                     'name': 'Context1',


### PR DESCRIPTION
- Fixed spelling: 'ellapsed' → 'elapsed'

I noticed the spelling when reading through some error output from PyVows. (Ironically, it was my own test suite which caused the errors, allowing me to notice the spelling in the first place!)

---

Ran PyVows’ tests after I made the change:

```
$ pyvows tests
 ============
 Vows Results
 ============
  ✓ OK » 486 honored • 0 broken (0.367988s)
```
