### PR TITLE
Colorize tracebacks (for readability)

### DIFF
--- a/pyvows/reporting.py
+++ b/pyvows/reporting.py
@@ -131,8 +131,11 @@ class VowsDefaultReporter(object):
         if self.verbosity >= V_NORMAL:
             traceback_msg = traceback.format_exception(exc_type, exc_value, exc_traceback)
             traceback_msg = self.format_traceback(traceback_msg, indentation)
-            print
-            print indentation + traceback_msg
+            print '\n{indent}{F.YELLOW}{traceback}{S.RESET_ALL}'.format(
+                F = Fore,
+                S = Style,
+                indent      = indentation,
+                traceback   = traceback_msg)
 
     def pretty_print(self):
         self.print_header('Vows Results')


### PR DESCRIPTION
After a certain number of failed vows, it can be difficult to scan the results and tell the tracebacks apart from what surrounds them.

This change colorizes the tracebacks yellow, which makes reading this kind of report much easier.
