### PR TITLE
#63: Use decimal values for `coverage`

### DIFF
--- a/pyvows/console.py
+++ b/pyvows/console.py
@@ -11,6 +11,7 @@ running tests, and the almighty `if __name__ == '__main__': main()`.
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 Bernardo Heynemann heynemann@gmail.com
+from __future__ import division
 
 import sys
 import os
@@ -152,6 +153,7 @@ def main():
                 with open(arguments.cover_report, 'w') as report:
                     report.write(xml)
 
+            arguments.cover_threshold /= 100.0
             reporter.print_coverage(xml, arguments.cover_threshold)
 
         else:

--- a/tests/reporting_vows.py
+++ b/tests/reporting_vows.py
@@ -66,7 +66,7 @@ class CoverageXMLParser(Vows.Context):
             expect(len(result['classes'])).to_equal(2)
 
         def should_be_overall_99(self, result):
-            expect(result['overall']).to_equal(99.0)
+            expect(result['overall']).to_equal(0.99)
 
         class TheFirstClass(Vows.Context):
 
@@ -77,7 +77,7 @@ class CoverageXMLParser(Vows.Context):
                 expect(klass['name']).to_equal('pyvows.console')
 
             def should_contain_linehate(self, klass):
-                expect(klass['line_rate']).to_equal(56.8)
+                expect(klass['line_rate']).to_equal(0.568)
 
             def should_contain_lines_uncovered(self, klass):
                 expect(klass['uncovered_lines']).to_equal(['12', '14'])
@@ -91,7 +91,7 @@ class CoverageXMLParser(Vows.Context):
                 expect(klass['name']).to_equal('tests.bla')
 
             def should_contain_linehate(self, klass):
-                expect(klass['line_rate']).to_equal(88.0)
+                expect(klass['line_rate']).to_equal(0.88)
 
             def should_contain_lines_uncovered(self, klass):
                 expect(klass['uncovered_lines']).to_equal(['2', '3'])


### PR DESCRIPTION
**NOTE: This change required a small (but important) modification to a few tests!**
## Rationale for change
- Python’s `str.format()` has a built-in mechanism for formatting a decimal value as a percent.
- In `reporting.py`, percents were calculated manually.  This meant that if an attempt was made to use `str.format()`’s built-in percentage format  on `coverage`, we had to divide by 100
- The manually-calculated percentages also had the potential to truncate digits, causing data loss; ideally, the raw data should be preserved until the time comes to format it as a string, at which point the number of digits should be specified in `str.format()`
## Benefits
- `reporting.py` now uses built-in methods to format percentages, which we don’t have to maintain (yay!)
- `coverage` is now consistent within `reporting.py` and values produced in the
- No digits will be truncated; client code can decide how many (or how few) digits to use with `str.format()`
- No need to manually insert a “%” into output strings
## Changed Tests
- This change required modifying a few tests to expect decimal values ranging from `0.000`–`1.000` (instead of `00.0`–`100.0`)
