### PR TITLE
Handling generative topics like simple topics if they produce an exception

### DIFF
--- a/pyvows/runner.py
+++ b/pyvows/runner.py
@@ -183,6 +183,7 @@ class VowsParallelRunner(object):
                     ctx_instance.topic_value = list(topic)
                     ctx_instance.generated_topic = True
                 except Exception as e:
+                    is_generator = False
                     topic = e
                     topic.error = ctx_instance.topic_error = sys.exc_info()
                     ctx_instance.topic_value = topic


### PR DESCRIPTION
If an exception occurs in a topic, the value remains iterable since
exceptions, somehow, are iterable. The result is that the entries (i.e.
the error message string) are handed down to the vows where they cause
strange errors that are hard to debug.

By resetting is_generator to False, these errors are handed to the vows
unchanged, so that they can actually see the error type and topic.error.

Since most of my topics are not supposed to produce exceptions, it would be
nice to have something like Vows.NotErrorContext that instead of just
adding a vow, does not execute any vows in case of an error in the
topic, and also prints a complete traceback of the error. The API might
be a function decorator for topic() that sets a function attribute
heeded by the runner.
