### PR TITLE
Tweak: track files to test using `Vows.suites`

### DIFF
--- a/pyvows/core.py
+++ b/pyvows/core.py
@@ -183,7 +183,7 @@ class Vows(object):
         return async_topic(topic)
 
     @staticmethod
-    def batch(method):
+    def batch(ctx_class):
         '''Class decorator.  Use on subclasses of `Vows.Context`.
 
         Test batches in PyVows are the largest unit of tests. The convention
@@ -191,8 +191,8 @@ class Vows(object):
         the file name.
 
         '''
-        Vows.batches[method.__name__] = method
-        _batch(method)
+        Vows.batches[ctx_class.__name__] = ctx_class
+        _batch(ctx_class)
 
     @classmethod
     def assertion(cls, method):
@@ -259,8 +259,9 @@ class Vows(object):
         #   *   Only used in `cli.py`
         path = os.path.abspath(path)
         files = utils.locate(pattern, path)
+        Vows.suites = set([f for f in files])
         sys.path.insert(0, path)
-
+            
         for module_path in files:
             module_name = os.path.splitext(
                 module_path.replace(path, '').replace('/', '.').lstrip('.')
@@ -273,7 +274,8 @@ class Vows(object):
         #
         #       *   Used by `run()` in `cli.py`
         #       *   Please add a useful description if you wrote this! :)
-        runner = VowsParallelRunner(Vows.batches,
+        runner = VowsParallelRunner(Vows.suites,
+                                    Vows.batches,
                                     Vows.Context,
                                     on_vow_success,
                                     on_vow_error,

--- a/pyvows/runner.py
+++ b/pyvows/runner.py
@@ -99,15 +99,16 @@ class VowsParallelRunner(object):
 
     pool = Pool(1000)
 
-    def __init__(self, batches, context_class, on_vow_success, on_vow_error, exclusion_patterns):
-        self.batches = batches # a batch is just a "top-level context"
+    def __init__(self, suites, batches, context_class, on_vow_success, on_vow_error, exclusion_patterns):
+        self.batches = batches  # a batch is just a "top-level context"
         self.context_class = context_class
         self.on_vow_success = on_vow_success
         self.on_vow_error = on_vow_error
         self.exclusion_patterns = exclusion_patterns
         if self.exclusion_patterns:
             self.exclusion_patterns = set([re.compile(x) for x in self.exclusion_patterns])
-
+        self.suites = suites  # a suite is a file with pyvows tests
+        
     def run(self):
         #   FIXME: Add Docstring
 

--- a/tests/filter_vows_to_run_vows.py
+++ b/tests/filter_vows_to_run_vows.py
@@ -50,21 +50,21 @@ class FilterOutVowsFromCommandLine(Vows.Context):
         def topic(self):
             return VowsParallelRunner
 
-        def can_be_initialized_with_5_arguments(self, topic):
+        def can_be_initialized_with_6_arguments(self, topic):
             try:
-                topic(None, None, None, None, None)
+                topic(None, None, None, None, None, None)
             except Exception as e:
                 expect(e).Not.to_be_instance_of(TypeError)
 
         def removes_appropriate_contexts(self, topic):
-            r = topic(None, None, None, None, ['foo', 'bar'])
+            r = topic(None, None, None, None, None, ['foo', 'bar'])
             col = []
             r.run_context_async(col, 'footer', r)
             expect(len(col)).to_equal(0)
 
         def leaves_unmatched_contexts(self, topic):
             VowsParallelRunner.teardown = None
-            r = topic(None, None, None, None, ['foo', 'bar'])
+            r = topic(None, None, None, None, None, ['foo', 'bar'])
             col = []
             r.run_context_async(col, 'baz', r)
             expect(len(col)).to_equal(1)


### PR DESCRIPTION
I used the “suite” term for consistency with the [PyVows website](http://pyvows.org).

Currently, `Vows.suites` is unused; however, I think it has potential to be quite helpful in the future.  

Since `Vows.suites` is created just once—at the same time that `Vows` is iterating over files —it should have nearly zero impact on performance.  
