### PR TITLE
Fixes ImportError exception occurring on windows

### DIFF
--- a/pyvows/core.py
+++ b/pyvows/core.py
@@ -261,10 +261,9 @@ class Vows(object):
         files = utils.locate(pattern, path)
         Vows.suites = set([f for f in files])
         sys.path.insert(0, path)
-            
         for module_path in files:
             module_name = os.path.splitext(
-                module_path.replace(path, '').replace('/', '.').lstrip('.')
+                module_path.replace(path, '').replace(os.path.sep, '.').lstrip('.')
             )[0]
             __import__(module_name)
 


### PR DESCRIPTION
Module names were not being properly constructed on windows due to using
the `/` character instead of `os.path.sep` when `Vows.collect` was called.
