### PR TITLE
Add --include switch to limit execution to specific contexts/vows

### DIFF
--- a/pyvows/cli.py
+++ b/pyvows/cli.py
@@ -51,7 +51,8 @@ class Messages(object):  # pragma: no cover
     cover_report = 'Store coverage report as %(metavar)s. (default: %(default)r)'
     xunit_output = 'Enable XUnit output. (default: %(default)s)'
     xunit_file = 'Store XUnit output as %(metavar)s. (default: %(default)r)'
-    exclude = 'Exclude tests and contexts that match regex-pattern %(metavar)s'
+    exclude = 'Exclude tests and contexts that match regex-pattern %(metavar)s [Mutually exclusive with --include]'
+    include = 'Include only tests and contexts that match regex-pattern %(metavar)s [Mutually exclusive with --exclude]'
     profile = 'Prints the 10 slowest topics. (default: %(default)s)'
     profile_threshold = 'Tests taking longer than %(metavar)s seconds are considered slow. (default: %(default)s)'
     no_color = 'Turn off colorized output. (default: %(default)s)'
@@ -73,6 +74,7 @@ class Parser(argparse.ArgumentParser):
 
         ### Filtering
         self.add_argument('-e', '--exclude', action='append', default=[], help=Messages.exclude, metavar=metavar('exclude'))
+        self.add_argument('-i', '--include', action='append', default=[], help=Messages.include, metavar=metavar('include'))
 
         ### Coverage
         cover_group = self.add_argument_group('Test Coverage')
@@ -123,7 +125,7 @@ class Parser(argparse.ArgumentParser):
         self.add_argument('path', nargs='?', default=os.curdir, help=Messages.path)
 
 
-def run(path, pattern, verbosity, show_progress, exclusion_patterns=None):
+def run(path, pattern, verbosity, show_progress, exclusion_patterns=None, inclusion_patterns=None):
     #   FIXME: Add Docstring
 
     # This calls Vows.run(), which then calls VowsRunner.run()
@@ -133,6 +135,8 @@ def run(path, pattern, verbosity, show_progress, exclusion_patterns=None):
 
     if exclusion_patterns:
         Vows.exclude(exclusion_patterns)
+    if inclusion_patterns:
+        Vows.include(inclusion_patterns)
 
     Vows.collect(path, pattern)
 
@@ -174,10 +178,8 @@ def main():
         cov.erase()
         cov.start()
 
-    prune = arguments.exclude
-
     verbosity = len(arguments.verbosity) if arguments.verbosity else 2
-    result = run(path, pattern, verbosity, arguments.progress, prune)
+    result = run(path, pattern, verbosity, arguments.progress, arguments.exclude, arguments.include)
     reporter = VowsDefaultReporter(result, verbosity)
 
     # Print test results first

--- a/pyvows/runner/abc.py
+++ b/pyvows/runner/abc.py
@@ -9,7 +9,6 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 Bernardo Heynemann heynemann@gmail.com
 
-import re
 import sys
 import time
 
@@ -21,21 +20,12 @@ from pyvows.utils import elapsed
 
 class VowsRunnerABC(object):
 
-    def __init__(self, suites, context_class, on_vow_success, on_vow_error, exclusion_patterns):
+    def __init__(self, suites, context_class, on_vow_success, on_vow_error, execution_plan):
         self.suites = suites  # a suite is a file with pyvows tests
         self.context_class = context_class
         self.on_vow_success = on_vow_success
         self.on_vow_error = on_vow_error
-        self.exclusion_patterns = exclusion_patterns
-        if self.exclusion_patterns:
-            self.exclusion_patterns = set([re.compile(x) for x in self.exclusion_patterns])
-
-    def is_excluded(self, name):
-        '''Return whether `name` is in `self.exclusion_patterns`.'''
-        for pattern in self.exclusion_patterns:
-            if pattern.search(name):
-                return True
-        return False
+        self.execution_plan = execution_plan
 
     def run(self):
         pass

--- a/tests/errors_in_topic_vows.py
+++ b/tests/errors_in_topic_vows.py
@@ -9,6 +9,8 @@
 # Copyright (c) 2013 Richard Lupton r.lupton@gmail.com
 
 from pyvows import Vows, expect
+from pyvows.runner import VowsRunner
+from pyvows.runner.executionplan import ExecutionPlanner
 
 
 # These tests demonstrate what happens when the topic function raises
@@ -37,14 +39,9 @@ class ErrorsInTopicFunction(Vows.Context):
 
     class WhenTopicRaisesAnUnexpectedException:
         def topic(self):
-            from pyvows.runner import VowsRunner
-            runner = VowsRunner(
-                {'dummySuite': set([WhenTopicRaisesAnException])},
-                Vows.Context,
-                None,
-                None,
-                set()
-            )
+            dummySuite = {'dummySuite': set([WhenTopicRaisesAnException])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan)
             return runner.run()
 
         def results_are_not_successful(self, topic):
@@ -55,14 +52,9 @@ class ErrorsInTopicFunction(Vows.Context):
 
     class WhenSubcontextTopicRaisesAnException:
         def topic(self):
-            from pyvows.runner import VowsRunner
-            runner = VowsRunner(
-                {'dummySuite': set([WhenTeardownIsDefined])},
-                Vows.Context,
-                None,
-                None,
-                set(['excluded_vows_do_not_block'])
-            )
+            dummySuite = {'dummySuite': set([WhenTeardownIsDefined])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set(['excluded_vows_do_not_block'])).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan)
             return runner.run()
 
         def results_are_not_successful(self, topic):

--- a/tests/filter_vows_to_run_vows.py
+++ b/tests/filter_vows_to_run_vows.py
@@ -10,8 +10,20 @@
 
 from pyvows import Vows, expect
 from pyvows import cli
-
 from pyvows.runner import VowsRunner
+from pyvows.runner.executionplan import ExecutionPlanner
+
+
+class VowsTestCopy1(Vows):
+    exclusion_patterns = set()
+    inclusion_patterns = set()
+    suites = dict()
+
+
+class VowsTestCopy2(Vows):
+    exclusion_patterns = set()
+    inclusion_patterns = set()
+    suites = dict()
 
 
 @Vows.batch
@@ -21,12 +33,6 @@ class FilterOutVowsFromCommandLine(Vows.Context):
         def topic(self):
             return cli
 
-        def should_be_not_error_when_called_with_5_args(self, topic):
-            try:
-                topic.run(None, None, None, None, None)
-            except Exception as e:
-                expect(e).Not.to_be_instance_of(TypeError)
-
         def should_hand_off_exclusions_to_Vows_class(self, topic):
 
             patterns = ['foo', 'bar', 'baz']
@@ -35,38 +41,102 @@ class FilterOutVowsFromCommandLine(Vows.Context):
             except Exception:
                 expect(Vows.exclusion_patterns).to_equal(patterns)
 
+        def should_hand_off_inclusions_to_Vows_class(self, topic):
+
+            patterns = ['foo', 'bar', 'baz']
+            try:
+                topic.run(None, '*_vows.py', 2, False, None, patterns)
+            except Exception:
+                expect(Vows.inclusion_patterns).to_equal(patterns)
+
     # TODO: add vow checking that there is a message about vow matching
 
     class Core(Vows.Context):
 
         def topic(self):
-            return Vows
+            return VowsTestCopy1
 
-        def should_have_exclude_method(self, topic):
-            expect(topic.exclude).to_be_a_function()
+        class RunMethod(Vows.Context):
 
-    class VowsRunner(Vows.Context):
+            class UsingAnExclusionPattern(Vows.Context):
+                def topic(self):
+                    VowsTestCopy1.exclusion_patterns = ['asdf']
+                    VowsTestCopy1.suites = {
+                        'dummySuite': [TestContext]
+                    }
+                    return VowsTestCopy1.run(None, None)
+
+                def should_not_run_the_excluded_vow(self, topic):
+                    expect(topic.contexts[0]['tests']).to_equal([])
+
+            class UsingAnInclusionPattern(Vows.Context):
+                def topic(self):
+                    VowsTestCopy2.inclusion_patterns = ['asdf']
+                    VowsTestCopy2.suites = {
+                        'dummySuite': [TestContext2]
+                    }
+                    return VowsTestCopy2.run(None, None)
+
+                def should_only_run_asdf(self, topic):
+                    expect([t['name'] for t in topic.contexts[0]['tests']]).to_equal(['asdf'])
+
+    class ResultsOfRunningTwoContextsWithConflictingIgnores(Vows.Context):
 
         def topic(self):
-            return VowsRunner
+            dummySuite = {'dummySuite': set([OverlappingIgnores1, OverlappingIgnores2])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan)
+            return runner.run()
 
-        def can_be_initialized_with_6_arguments(self, topic):
-            try:
-                topic(None, None, None, None, None)
-            except Exception as e:
-                expect(e).Not.to_be_instance_of(TypeError)
+        def context1_ran_only_test2(self, topic):
+            testsRan = [context for context in topic.contexts if context['name'] == 'OverlappingIgnores1'][0]['tests']
+            testNames = [t['name'] for t in testsRan]
+            expect(testNames).to_equal(['test2'])
 
-        def removes_appropriate_contexts(self, topic):
-            r = topic(None, None, None, None, set(['foo', 'bar']))
-            col = []
-            r.run_context(col, 'footer', r)
-            expect(len(col)).to_equal(0)
+        def context2_ran_only_test1(self, topic):
+            testsRan = [context for context in topic.contexts if context['name'] == 'OverlappingIgnores2'][0]['tests']
+            testNames = [t['name'] for t in testsRan]
+            expect(testNames).to_equal(['test1'])
 
-        def leaves_unmatched_contexts(self, topic):
-            VowsRunner.teardown = lambda self: None
-            r = topic(None, None, None, None, ['foo', 'bar'])
-            col = []
-            r.run_context(col, 'baz', r)
-            expect(len(col)).to_equal(1)
-            r.run_context(col, 'bip', r)
-            expect(len(col)).to_equal(2)
+
+class TestContext(Vows.Context):
+    def topic(self):
+        return 'test'
+
+    def asdf(self, topic):
+        expect(topic).to_equal('test')
+
+
+class TestContext2(Vows.Context):
+    def topic(self):
+        return 'test'
+
+    def asdf(self, topic):
+        expect(topic).to_equal('test')
+
+    def fdsa(self, topic):
+        expect(topic).to_equal('test')
+
+
+class OverlappingIgnores1(Vows.Context):
+    def topic(self):
+        self.ignore('test1')
+        return 1
+
+    def test1(self, topic):
+        expect(topic).to_equal(1)
+
+    def test2(self, topic):
+        expect(topic).to_equal(1)
+
+
+class OverlappingIgnores2(Vows.Context):
+    def topic(self):
+        self.ignore('test2')
+        return 1
+
+    def test1(self, topic):
+        expect(topic).to_equal(1)
+
+    def test2(self, topic):
+        expect(topic).to_equal(1)

--- a/tests/prune_execution_vows.py
+++ b/tests/prune_execution_vows.py
@@ -17,33 +17,34 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_tree_matches(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubA': {
                                     'name': 'SubA',
                                     'id': 'UnrunnableBatch.SubA',
                                     'vows': [],
-                                    'contexts': []
-                                }, {
+                                    'contexts': {}
+                                },
+                                'SubB': {
                                     'name': 'SubB',
                                     'id': 'UnrunnableBatch.SubB',
                                     'vows': ['testB_0'],
-                                    'contexts': [
-                                        {
+                                    'contexts': {
+                                        'SubC': {
                                             'name': 'SubC',
                                             'id': 'UnrunnableBatch.SubB.SubC',
                                             'vows': ['testB1_0', 'testB1_1'],
-                                            'contexts': []
+                                            'contexts': {}
                                         }
-                                    ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)
@@ -60,21 +61,21 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_excluded_context_is_not_included(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubA': {
                                     'name': 'SubA',
                                     'id': 'UnrunnableBatch.SubA',
                                     'vows': [],
-                                    'contexts': []
+                                    'contexts': {}
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)
@@ -91,7 +92,7 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_excluded_context_is_not_included(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': []
+                    'contexts': {}
                 }
             }
             expect(topic).to_equal(baseline)
@@ -108,33 +109,34 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_excluded_context_is_not_included(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubA': {
                                     'name': 'SubA',
                                     'id': 'UnrunnableBatch.SubA',
                                     'vows': [],
-                                    'contexts': []
-                                }, {
+                                    'contexts': {}
+                                },
+                                'SubB': {
                                     'name': 'SubB',
                                     'id': 'UnrunnableBatch.SubB',
                                     'vows': ['testB_0'],
-                                    'contexts': [
-                                        {
+                                    'contexts': {
+                                        'SubC': {
                                             'name': 'SubC',
                                             'id': 'UnrunnableBatch.SubB.SubC',
                                             'vows': [],
-                                            'contexts': []
+                                            'contexts': {}
                                         }
-                                    ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)
@@ -164,21 +166,21 @@ class DiscoveringExecutionTree(Vows.Context):
         def target_context_topic_and_ancestors_topics_are_included(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubB': {
                                     'name': 'SubB',
                                     'id': 'UnrunnableBatch.SubB',
                                     'vows': [],
-                                    'contexts': []
+                                    'contexts': {}
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)
@@ -195,28 +197,28 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_only_the_targeted_vow_is_run_on_the_context(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubB': {
                                     'name': 'SubB',
                                     'id': 'UnrunnableBatch.SubB',
                                     'vows': [],
-                                    'contexts': [
-                                        {
+                                    'contexts': {
+                                        'SubC': {
                                             'name': 'SubC',
                                             'id': 'UnrunnableBatch.SubB.SubC',
                                             'vows': ['testB1_0'],
-                                            'contexts': []
+                                            'contexts': {}
                                         }
-                                    ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)
@@ -233,33 +235,34 @@ class DiscoveringExecutionTree(Vows.Context):
         def the_other_batch_is_not_included(self, topic):
             baseline = {
                 'dummySuite': {
-                    'contexts': [
-                        {
+                    'contexts': {
+                        'UnrunnableBatch': {
                             'name': 'UnrunnableBatch',
                             'id': 'UnrunnableBatch',
                             'vows': [],
-                            'contexts': [
-                                {
+                            'contexts': {
+                                'SubA': {
                                     'name': 'SubA',
                                     'id': 'UnrunnableBatch.SubA',
                                     'vows': [],
-                                    'contexts': []
-                                }, {
+                                    'contexts': {}
+                                },
+                                'SubB': {
                                     'name': 'SubB',
                                     'id': 'UnrunnableBatch.SubB',
                                     'vows': ['testB_0'],
-                                    'contexts': [
-                                        {
+                                    'contexts': {
+                                        'SubC': {
                                             'name': 'SubC',
                                             'id': 'UnrunnableBatch.SubB.SubC',
                                             'vows': ['testB1_0', 'testB1_1'],
-                                            'contexts': []
+                                            'contexts': {}
                                         }
-                                    ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    ]
+                    }
                 }
             }
             expect(topic).to_equal(baseline)


### PR DESCRIPTION
This is an attempt to close #22 by adding a new cli switch. The new switch (--include) works similarly to the exclude switch except the search for the regex happens against the "full name" of the context/vow (e.g. TheGoodThings.ABanana.WhenPeeled.returns_a_peeled_banana).

Example usage:
pyvows --include returns_a_peeled_banana
pyvows --include WhenPeeled.*

Limitations I know about:
- The --include and --exclude switches are mutually exclusive for simplicity
- There is currently no way to specify only running a specific instance of a generated topic
- Because Context.ignore can dynamically change what is executed, it is theoretically possible for a user to --include something that eventually gets ignored anyway
