### PR TITLE
xunit reporter should report full exception instead of just VowsTopicError

### DIFF
--- a/pyvows/reporting/xunit.py
+++ b/pyvows/reporting/xunit.py
@@ -75,11 +75,11 @@ class XUnitReporter(object):
         topic_node.setAttribute('time', '0.0')
         if context.get('error', None):
             e = context['error']
-            error_msg = 'Error in {0!s}'.format(e.source)
+            error_msg = 'Error in {0!s}: {1!s}'.format(e.source, e.exc_info[1])
             error_tb = traceback.format_exception(*e.exc_info)
 
             failure_node = document.createElement('failure')
-            failure_node.setAttribute('type', e.__class__.__name__)
+            failure_node.setAttribute('type', e.exc_info[0].__name__)
             failure_node.setAttribute('message', error_msg)
             failure_text = document.createTextNode(''.join(error_tb))
             failure_node.appendChild(failure_text)

--- a/tests/reporting/xunit_reporter_vows.py
+++ b/tests/reporting/xunit_reporter_vows.py
@@ -84,6 +84,11 @@ class XUnitReporterVows(Vows.Context):
 
     class WhenShowingATopicError(Vows.Context):
         def topic(self):
+            try:
+                raise Exception('asdf')
+            except:
+                test_exc_info = sys.exc_info()
+
             result = ResultMock()
             result.successful_tests = 1
             result.errored_tests = 0
@@ -93,7 +98,7 @@ class XUnitReporterVows(Vows.Context):
                 {
                     'name': 'Context1',
                     'tests': [],
-                    'error': VowsTopicError('topic', sys.exc_info()),
+                    'error': VowsTopicError('topic', test_exc_info),
                     'contexts': []
                 }
             ]
@@ -107,6 +112,8 @@ class XUnitReporterVows(Vows.Context):
             def topic(self, testcase):
                 return testcase.firstChild
 
-            def should_have_exception_attributes(self, topic):
-                expect(topic.getAttribute('type')).to_equal('VowsTopicError')
-                expect(topic.getAttribute('message')).to_equal('Error in topic')
+            def should_have_original_exception_type(self, topic):
+                expect(topic.getAttribute('type')).to_equal('Exception')
+
+            def should_have_original_exception_message(self, topic):
+                expect(topic.getAttribute('message')).to_equal('Error in topic: asdf')


### PR DESCRIPTION
Currently, the xunit reporter is only reporting that a topic/setup/teardown had an error, but it isn't reporting what the error is. With this change, xunit now includes a failure message with the original details and the type of the error matches the original error instead of VowsTopicError.
