### PR TITLE
runner.utils: Print the function name when complaining about missing code

### DIFF
--- a/pyvows/runner/utils.py
+++ b/pyvows/runner/utils.py
@@ -42,7 +42,8 @@ def get_topics_for(topic_function, ctx_obj):
     code = get_code_for(topic_function)
  
     if not code:
-        raise RuntimeError('Function %s does not have a code property')
+        raise RuntimeError(
+            'Function %s does not have a code property' % topic_function)
  
     expected_args = code.co_argcount - 1
  


### PR DESCRIPTION
The exception message has had a %s marker since it was added in
0cefbe36 (Parallel running with inherited topics done, 2011-04-29),
but nobody ever set a value for that marker.
