### PR TITLE
runner.gevent: Shift None check for topic_func earlier

### DIFF
--- a/pyvows/runner/gevent.py
+++ b/pyvows/runner/gevent.py
@@ -94,12 +94,12 @@ class VowsParallelRunner(VowsRunnerABC):
 
             try:
                 topic_func = ctx_obj.topic
+                if topic_func is None:
+                    return None
+
                 topic_list = get_topics_for(topic_func, ctx_obj)
 
                 start_time = time.time()
-
-                if topic_func is None:
-                    return None
 
                 topic = topic_func(*topic_list)
                 ctx_result['topic_elapsed'] = elapsed(start_time)


### PR DESCRIPTION
Avoid:

  Traceback (most recent call last):
    File "/.../pyvows/runner/gevent.py", line 97, in _run_setup_and_topic
      topic_list = get_topics_for(topic_func, ctx_obj)
    File "/.../pyvows/runner/utils.py", line 46, in get_topics_for
      'Function %s does not have a code property' % topic_function)
  RuntimeError: Function None does not have a code property

because VowsParallelRunner._run_setup_and_topic was calling
get_topics_for (which chokes when it's topic_function is None) before
checking for a None value.

The fixes a broken check from 59e67374 (topics can be none, we need to
validate against that, 2014-06-02).
