### PR TITLE
Add ability to capture output

### DIFF
--- a/pyvows/cli.py
+++ b/pyvows/cli.py
@@ -58,6 +58,7 @@ class Messages(object):  # pragma: no cover
     no_color = 'Turn off colorized output. (default: %(default)s)'
     progress = 'Show progress ticks during testing. (default: %(default)s)'
     template = 'Print a PyVows test file template. (Disables testing)'
+    capture_output = 'Capture stdout and stderr during test execution (default: %(default)s)'
 
 
 class Parser(argparse.ArgumentParser):
@@ -120,12 +121,13 @@ class Parser(argparse.ArgumentParser):
         self.add_argument('--no-color', action='store_true', default=False, help=Messages.no_color)
         self.add_argument('--progress', action='store_true', dest='progress', default=False, help=Messages.progress)
         self.add_argument('--version', action='version', version='%(prog)s {0}'.format(version.to_str()))
+        self.add_argument('--capture-output', action='store_true', default=False, help=Messages.capture_output)
         self.add_argument('-v', action='append_const', dest='verbosity', const=1, help=Messages.verbosity)
 
         self.add_argument('path', nargs='?', default=os.curdir, help=Messages.path)
 
 
-def run(path, pattern, verbosity, show_progress, exclusion_patterns=None, inclusion_patterns=None):
+def run(path, pattern, verbosity, show_progress, exclusion_patterns=None, inclusion_patterns=None, capture_output=False):
     #   FIXME: Add Docstring
 
     # This calls Vows.run(), which then calls VowsRunner.run()
@@ -142,7 +144,7 @@ def run(path, pattern, verbosity, show_progress, exclusion_patterns=None, inclus
 
     on_success = show_progress and VowsDefaultReporter.on_vow_success or None
     on_error = show_progress and VowsDefaultReporter.on_vow_error or None
-    result = Vows.run(on_success, on_error)
+    result = Vows.run(on_success, on_error, capture_output)
 
     return result
 
@@ -179,7 +181,15 @@ def main():
         cov.start()
 
     verbosity = len(arguments.verbosity) if arguments.verbosity else 2
-    result = run(path, pattern, verbosity, arguments.progress, arguments.exclude, arguments.include)
+    result = run(
+        path,
+        pattern,
+        verbosity,
+        arguments.progress,
+        exclusion_patterns=arguments.exclude,
+        inclusion_patterns=arguments.include,
+        capture_output=arguments.capture_output
+    )
     reporter = VowsDefaultReporter(result, verbosity)
 
     # Print test results first

--- a/pyvows/core.py
+++ b/pyvows/core.py
@@ -166,7 +166,7 @@ class Vows(object):
         cls.inclusion_patterns = test_name_pattern
 
     @classmethod
-    def run(cls, on_vow_success, on_vow_error):
+    def run(cls, on_vow_success, on_vow_error, capture_error=False):
         #   FIXME: Add Docstring
         #
         #       *   Used by `run()` in `cli.py`
@@ -179,6 +179,7 @@ class Vows(object):
             cls.Context,
             on_vow_success,
             on_vow_error,
-            execution_plan
+            execution_plan,
+            capture_error
         )
         return runner.run()

--- a/pyvows/runner/abc.py
+++ b/pyvows/runner/abc.py
@@ -20,12 +20,13 @@ from pyvows.utils import elapsed
 
 class VowsRunnerABC(object):
 
-    def __init__(self, suites, context_class, on_vow_success, on_vow_error, execution_plan):
+    def __init__(self, suites, context_class, on_vow_success, on_vow_error, execution_plan, capture_output=False):
         self.suites = suites  # a suite is a file with pyvows tests
         self.context_class = context_class
         self.on_vow_success = on_vow_success
         self.on_vow_error = on_vow_error
         self.execution_plan = execution_plan
+        self.capture_output = capture_output
 
     def run(self):
         pass

--- a/tests/captured_output_vows.py
+++ b/tests/captured_output_vows.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import sys
+
+from pyvows import Vows, expect
+from pyvows.runner.gevent import VowsParallelRunner
+from pyvows.runner.executionplan import ExecutionPlanner
+from pyvows.runner import VowsRunner
+
+
+@Vows.batch
+class CapturedOutputVows(Vows.Context):
+
+    class ResultsFromContextThatExplicitlyCapturesOutput(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([OutputSomeStuff])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            return runner.run()
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        class TopContextStdout(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['stdout']
+
+            def has_setup_topic_teardown(self, topic):
+                expect(topic).to_equal('setup\ntopic\nteardown\n')
+
+        class TopContextStderr(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['stderr']
+
+            def has_setup_topic_teardown_err(self, topic):
+                expect(topic).to_equal('setup-err\ntopic-err\nteardown-err\n')
+
+        class SubcontextStdout(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['contexts'][0]['stdout']
+
+            def has_subcontext_topic(self, topic):
+                expect(topic).to_equal('subcontext-topic\n')
+
+        class SubcontextStderr(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['contexts'][0]['stderr']
+
+            def has_subcontext_topic_err(self, topic):
+                expect(topic).to_equal('subcontext-topic-err\n')
+
+        class TopContextVowStdout(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['tests'][0]['stdout']
+
+            def has_vow(self, topic):
+                expect(topic).to_equal('vow\n')
+
+        class TopContextVowStderr(Vows.Context):
+            def topic(self, results):
+                return results.contexts[0]['tests'][0]['stderr']
+
+            def has_vow_err(self, topic):
+                expect(topic).to_equal('vow-err\n')
+
+    class ResultsFromContextThatPrintsWhenSysStreamsArePatched(ResultsFromContextThatExplicitlyCapturesOutput):
+        def topic(self):
+            dummySuite = {'dummySuite': set([PrintSomeStuff])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, True)
+            return runner.run()
+
+
+class OutputSomeStuff(Vows.Context):
+    def setup(self):
+        VowsParallelRunner.output.stdout.write('setup\n')
+        VowsParallelRunner.output.stderr.write('setup-err\n')
+
+    def topic(self):
+        VowsParallelRunner.output.stdout.write('topic\n')
+        VowsParallelRunner.output.stderr.write('topic-err\n')
+
+    def teardown(self):
+        VowsParallelRunner.output.stdout.write('teardown\n')
+        VowsParallelRunner.output.stderr.write('teardown-err\n')
+
+    def vow(self, topic):
+        VowsParallelRunner.output.stdout.write('vow\n')
+        VowsParallelRunner.output.stderr.write('vow-err\n')
+
+    class OutputFromSubcontext(Vows.Context):
+        def topic(self):
+            VowsParallelRunner.output.stdout.write('subcontext-topic\n')
+            VowsParallelRunner.output.stderr.write('subcontext-topic-err\n')
+
+
+class PrintSomeStuff(Vows.Context):
+    def setup(self):
+        print('setup')
+        print('setup-err', file=sys.stderr)
+
+    def topic(self):
+        print('topic')
+        print('topic-err', file=sys.stderr)
+
+    def teardown(self):
+        print('teardown')
+        print('teardown-err', file=sys.stderr)
+
+    def vow(self, topic):
+        print('vow')
+        print('vow-err', file=sys.stderr)
+
+    class PrintFromSubcontext(Vows.Context):
+        def topic(self):
+            print('subcontext-topic')
+            print('subcontext-topic-err', file=sys.stderr)

--- a/tests/errors_in_topic_vows.py
+++ b/tests/errors_in_topic_vows.py
@@ -41,7 +41,7 @@ class ErrorsInTopicFunction(Vows.Context):
         def topic(self):
             dummySuite = {'dummySuite': set([WhenTopicRaisesAnException])}
             execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
-            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan)
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
             return runner.run()
 
         def results_are_not_successful(self, topic):
@@ -54,7 +54,7 @@ class ErrorsInTopicFunction(Vows.Context):
         def topic(self):
             dummySuite = {'dummySuite': set([WhenTeardownIsDefined])}
             execution_plan = ExecutionPlanner(dummySuite, set(), set(['excluded_vows_do_not_block'])).plan()
-            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan)
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
             return runner.run()
 
         def results_are_not_successful(self, topic):


### PR DESCRIPTION
Added ways to capture output associated with a context or vow where it was generated. An optional switch wraps stdout and stderr, or tests can directly write to VowsParallelReporter.output['stdout'] or VowsParallelReporter.output['stderr'] as needed. XUnitReporter puts this data in the system-out and system-err nodes.

Also, fix bug in xunit reporting when a vow for a captured error fails.
