### PR TITLE
Programatically skip contexts and/or vows

### DIFF
--- a/pyvows/core.py
+++ b/pyvows/core.py
@@ -17,7 +17,7 @@ import copy
 import preggy
 
 from pyvows import utils
-from pyvows.decorators import _batch, async_topic, capture_error
+from pyvows.decorators import _batch, async_topic, capture_error, skip_if
 from pyvows.runner import VowsRunner
 from pyvows.runner.executionplan import ExecutionPlanner
 
@@ -127,6 +127,14 @@ class Vows(object):
         return capture_error(topic_func)
 
     @staticmethod
+    def skip_if(condition, reason):
+        return skip_if(condition, reason)
+
+    @staticmethod
+    def skip(reason):
+        return skip_if(True, reason)
+
+    @staticmethod
     def batch(ctx_class):
         '''Class decorator.  Use on subclasses of `Vows.Context`.
 
@@ -141,7 +149,7 @@ class Vows(object):
         if suite not in Vows.suites:
             Vows.suites[suite] = set()
         Vows.suites[suite].add(ctx_class)
-        _batch(ctx_class)
+        return _batch(ctx_class)
 
     @classmethod
     def collect(cls, path, pattern):

--- a/pyvows/decorators.py
+++ b/pyvows/decorators.py
@@ -59,19 +59,27 @@ def capture_error(topic_func):
 
 
 def skip_if(condition, reason):
-    '''Topic or vow decorator.  Causes a topic or vow to be skipped if `condition` is True
+    '''Topic or vow or context decorator.  Causes a topic or vow to be skipped if `condition` is True
 
     This is equivilent to `if condition: raise SkipTest(reason)`
     '''
+    from pyvows.core import Vows
 
-    def real_decorator(topic_or_vow):
+    def real_decorator(topic_or_vow_or_context):
         if not condition:
-            return topic_or_vow
+            return topic_or_vow_or_context
 
-        def wrapper(*args, **kwargs):
-            raise SkipTest(reason)
-        wrapper.__name__ = topic_or_vow.__name__
-        return wrapper
+        if type(topic_or_vow_or_context) == type(Vows.Context):
+            class klass_wrapper(topic_or_vow_or_context):
+                def topic(self):
+                    raise SkipTest(reason)
+            klass_wrapper.__name__ = topic_or_vow_or_context.__name__
+            return klass_wrapper
+        else:
+            def wrapper(*args, **kwargs):
+                raise SkipTest(reason)
+            wrapper.__name__ = topic_or_vow_or_context.__name__
+            return wrapper
     return real_decorator
 
 #-------------------------------------------------------------------------------------------------

--- a/pyvows/decorators.py
+++ b/pyvows/decorators.py
@@ -10,11 +10,12 @@
 # Copyright (c) 2011 Bernardo Heynemann heynemann@gmail.com
 
 from functools import wraps
-import re
 
 from pyvows.async_topic import VowsAsyncTopic
+from pyvows.runner import SkipTest
 
 #-------------------------------------------------------------------------------------------------
+
 
 def _batch(klass):
     # This is underscored-prefixed because the only intended use (via
@@ -39,6 +40,7 @@ def async_topic(topic):
     wrapper.__name__ = topic.__name__
     return wrapper
 
+
 def capture_error(topic_func):
     '''Topic decorator.  Allows any errors raised to become the topic value.
 
@@ -55,7 +57,25 @@ def capture_error(topic_func):
     wrapper.__name__ = topic_func.__name__
     return wrapper
 
+
+def skip_if(condition, reason):
+    '''Topic or vow decorator.  Causes a topic or vow to be skipped if `condition` is True
+
+    This is equivilent to `if condition: raise SkipTest(reason)`
+    '''
+
+    def real_decorator(topic_or_vow):
+        if not condition:
+            return topic_or_vow
+
+        def wrapper(*args, **kwargs):
+            raise SkipTest(reason)
+        wrapper.__name__ = topic_or_vow.__name__
+        return wrapper
+    return real_decorator
+
 #-------------------------------------------------------------------------------------------------
+
 
 class FunctionWrapper(object):
 

--- a/pyvows/reporting/common.py
+++ b/pyvows/reporting/common.py
@@ -13,6 +13,7 @@ from __future__ import division, print_function
 
 import re
 import traceback
+import sys
 
 from pyvows.color import yellow, green, red, bold
 
@@ -56,6 +57,7 @@ class VowsReporter(object):
 
     HONORED = green('✓')
     BROKEN = red('✗')
+    SKIPPED = '?'
     TAB = '  '
 
     def __init__(self, result, verbosity):
@@ -148,7 +150,7 @@ class VowsReporter(object):
     #-------------------------------------------------------------------------
     #   Printing Methods
     #-------------------------------------------------------------------------
-    def humanized_print(self, msg, indentation=None):
+    def humanized_print(self, msg, indentation=None, file=sys.stdout):
         '''Passes `msg` through multiple text filters to make the output
         appear more like normal text, then prints it (indented by
         `indentation`).
@@ -161,20 +163,20 @@ class VowsReporter(object):
         msg = msg.capitalize()
         msg = self.format_python_constants(msg)
 
-        print(self.indent_msg(msg, indentation))
+        print(self.indent_msg(msg, indentation), file=file)
 
-    def print_traceback(self, err_type, err_obj, err_traceback):
+    def print_traceback(self, err_type, err_obj, err_traceback, file=sys.stdout):
         '''Prints a color-formatted traceback with appropriate indentation.'''
         if isinstance(err_obj, AssertionError):
             error_msg = err_obj
         else:
             error_msg = unicode(err_obj)
 
-        print(self.indent_msg(red(error_msg)))
+        print(self.indent_msg(red(error_msg)), file=file)
 
         if self.verbosity >= V_NORMAL:
             traceback_msg = traceback.format_exception(err_type, err_obj, err_traceback)
             traceback_msg = self.format_traceback(traceback_msg)
             traceback_msg = '\n{traceback}'.format(traceback=traceback_msg)
             traceback_msg = self.indent_msg(yellow(traceback_msg))
-            print(traceback_msg)
+            print(traceback_msg, file=file)

--- a/pyvows/reporting/test.py
+++ b/pyvows/reporting/test.py
@@ -11,14 +11,15 @@ have been run.
 from __future__ import division, print_function
 
 import sys
+from StringIO import StringIO
 
 from pyvows.color import yellow, red, blue
-from pyvows.errors import VowsInternalError
 from pyvows.reporting.common import (
     ensure_encoded,
     V_EXTRA_VERBOSE,
     V_VERBOSE,
     VowsReporter,)
+from pyvows.result import VowsResult
 
 
 class VowsTestReporter(VowsReporter):
@@ -55,81 +56,95 @@ class VowsTestReporter(VowsReporter):
     #-------------------------------------------------------------------------
     #   Printing Methods
     #-------------------------------------------------------------------------
-    def pretty_print(self):
+    def pretty_print(self, file=sys.stdout):
         '''Prints PyVows test results.'''
-        print(self.header('Vows Results'))
+        print(self.header('Vows Results'), file=file)
 
         if not self.result.contexts:
             # FIXME:
             #   If no vows are found, how could any be broken?
-            print(
-                '{indent}{broken} No vows found! » 0 honored • 0 broken (0.0s)'.format(
-                    indent=self.TAB * self.indent,
-                    broken=VowsReporter.BROKEN)
-                )
+            summary = '{indent}{broken} No vows found! » 0 honored • 0 broken • 0 skipped (0.0s)'.format(
+                indent=self.TAB * self.indent,
+                broken=VowsReporter.BROKEN)
+            print(summary, file=file)
             return
 
         if self.verbosity >= V_VERBOSE or self.result.errored_tests:
-            print()
+            print(file=file)
 
         for context in self.result.contexts:
-            self.print_context(context['name'], context)
+            self.print_context(context['name'], context, file=file)
 
-        print('{0}{1} OK » {honored:d} honored • {broken:d} broken ({time:.6f}s)'.format(
+        summary = '{0}{1} OK » {honored:d} honored • {broken:d} broken • {skipped:d} skipped ({time:.6f}s)'.format(
             self.TAB * self.indent,
             self.status_symbol,
             honored=self.result.successful_tests,
             broken=self.result.errored_tests,
-            time=self.result.elapsed_time))
+            skipped=self.result.skipped_tests,
+            time=self.result.elapsed_time
+        )
+        print(summary, file=file)
+        print(file=file)
 
-        print()
-
-    def print_context(self, name, context):
+    def print_context(self, name, context, file=sys.stdout):
         #   FIXME: Add Docstring
         #
         #       *   Is this only used in certain cases?
         #           *   If so, which?
         self.indent += 1
 
-        if (self.verbosity >= V_VERBOSE or
-                not self.result.eval_context(context)):
-            self.humanized_print(name)
+        if (self.verbosity >= V_VERBOSE or not self.result.eval_context(context)):
+            contextName = StringIO()
+            self.humanized_print(name, file=contextName)
+            contextName = contextName.getvalue().replace('\n', '')
+            if context.get('skip', None):
+                contextName += ' (SKIPPED: {0})'.format(str(context['skip']))
+            print(contextName, file=file)
 
-        def _print_successful_context():
+        def _print_successful_test():
             honored = ensure_encoded(VowsReporter.HONORED)
             topic = ensure_encoded(test['topic'])
             name = ensure_encoded(test['name'])
 
             if self.verbosity == V_VERBOSE:
-                self.humanized_print('{0} {1}'.format(honored, name))
+                self.humanized_print('{0} {1}'.format(honored, name), file=file)
             elif self.verbosity >= V_EXTRA_VERBOSE:
                 if test['enumerated']:
-                    self.humanized_print('{0} {1} - {2}'.format(honored, topic, name))
+                    self.humanized_print('{0} {1} - {2}'.format(honored, topic, name), file=file)
                 else:
-                    self.humanized_print('{0} {1}'.format(honored, name))
+                    self.humanized_print('{0} {1}'.format(honored, name), file=file)
 
-        def _print_failed_context():
+        def _print_skipped_test():
+            if self.verbosity >= V_VERBOSE:
+                message = StringIO()
+                self.humanized_print('{0} {1}'.format(VowsReporter.SKIPPED, test['name']), file=message)
+                message = message.getvalue().replace('\n', '')
+                if test['skip'] != context['skip']:
+                    message = '{0} (SKIPPED: {1})'.format(message, str(test['skip']))
+                print(message, file=file)
+
+        def _print_failed_test():
             ctx = test['context_instance']
 
             def _print_traceback():
                 self.indent += 2
-                
+
                 ### NOTE:
                 ###     Commented out try/except; potential debugging hinderance
-                
+
                 #try:
 
                 traceback_args = (test['error']['type'],
                                   test['error']['value'],
                                   test['error']['traceback'])
-                self.print_traceback(*traceback_args)
-                
+                self.print_traceback(*traceback_args, file=file)
+
                 # except Exception:
                 #     # should never occur!
                 #     err_msg = '''Unexpected error in PyVows!
                 #                  PyVows error occurred in: ({0!s})
                 #                  Context was: {1!r}
-                # 
+                #
                 #               '''
                 #     # from os.path import abspath
                 #     raise VowsInternalError(err_msg, 'pyvows.reporting.test', ctx)
@@ -137,23 +152,19 @@ class VowsTestReporter(VowsReporter):
                 # print file and line number
                 if 'file' in test:
                     file_msg = 'found in {test[file]} at line {test[lineno]}'.format(test=test)
-                    print('\n', 
-                          self.indent_msg(red(file_msg)), 
-                          '\n')
+                    print('\n', self.indent_msg(red(file_msg)), '\n', file=file)
 
                 self.indent -= 2
 
-            self.humanized_print('{0} {test}'.format(
-                VowsReporter.BROKEN,
-                test=test['name']))
+            self.humanized_print('{0} {test}'.format(VowsReporter.BROKEN, test=test['name']), file=file)
 
             # print generated topic (if applicable)
             if ctx.generated_topic:
                 value = yellow(test['topic'])
-                self.humanized_print('')
-                self.humanized_print('\tTopic value:')
-                self.humanized_print('\t{value}'.format(value=value))
-                self.humanized_print('\n' * 2)
+                self.humanized_print('', file=file)
+                self.humanized_print('\tTopic value:', file=file)
+                self.humanized_print('\t{value}'.format(value=value), file=file)
+                self.humanized_print('\n' * 2, file=file)
 
             # print traceback
             _print_traceback()
@@ -161,19 +172,20 @@ class VowsTestReporter(VowsReporter):
         # Show any error raised by the setup, topic or teardown functions
         if context.get('error', None):
             e = context['error']
-            print('\n', self.indent_msg(blue("Error in {0!s}:".format(e.source))))
-            self.print_traceback(*e.exc_info)
-            print(self.indent_msg(red("Nested tests following this error have not been run.")))
+            print('\n', self.indent_msg(blue("Error in {0!s}:".format(e.source))), file=file)
+            self.print_traceback(*e.exc_info, file=file)
 
         else:
             for test in context['tests']:
-                if test['succeeded']:
-                    _print_successful_context()
+                if VowsResult.test_is_successful(test):
+                    _print_successful_test()
+                elif test['skip']:
+                    _print_skipped_test()
                 else:
-                    _print_failed_context()
+                    _print_failed_test()
 
         # I hereby (re)curse you...!
         for context in context['contexts']:
-            self.print_context(context['name'], context)
+            self.print_context(context['name'], context, file=file)
 
         self.indent -= 1

--- a/pyvows/runner/__init__.py
+++ b/pyvows/runner/__init__.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 '''This package contains different runtime implementations for PyVows.  PyVows will
 select the fastest possible runner, using fallbacks if unavailable.
- 
 '''
 
 
-try:
-    ##  GEvent
-    from pyvows.runner.gevent import VowsParallelRunner as VowsRunner
-except ImportError as e:
-    ##  Sequential
-    from pyvows.runner.sequential import VowsSequentialRunner as VowsRunner
-finally:
-    __all__ = ('VowsRunner')
+class SkipTest(Exception):
+    pass
+
+from pyvows.runner.gevent import VowsParallelRunner as VowsRunner
+
+__all__ = ('VowsRunner', 'SkipTest')

--- a/tests/bugs/64_vows.py
+++ b/tests/bugs/64_vows.py
@@ -11,13 +11,14 @@ from pyvows import Vows, expect
 from pyvows.result import VowsResult
 from pyvows.reporting import VowsTestReporter  # , VowsDefaultReporter
 
+from StringIO import StringIO
+
 
 @Vows.batch
 class VowsTestReporterExceptions(Vows.Context):
 
     def topic(self):
         v = VowsTestReporter(VowsResult(), 0)
-        v.humanized_print = lambda a: None
         return v
 
     def should_not_raise_TypeError_on_tests_without_a_topic(self, topic):
@@ -28,12 +29,14 @@ class VowsTestReporterExceptions(Vows.Context):
                     'context_instance': Vows.Context(),
                     'error': {'type': '',
                               'value': '',
-                              'traceback': ''}
+                              'traceback': ''},
+                    'skip': None
                     }
             context = {'tests': [test],
                        'contexts': []
                        }
-            topic.print_context('Derp', context)
+            output = StringIO()
+            topic.print_context('Derp', context, file=output)
         except AssertionError as e:
             expect(e).to_be_an_error_like(AssertionError)
             expect(e).Not.to_be_an_error_like(TypeError)

--- a/tests/reporting/error_reporting_vows.py
+++ b/tests/reporting/error_reporting_vows.py
@@ -12,6 +12,8 @@ from pyvows import Vows, expect
 from pyvows.reporting import VowsDefaultReporter
 from pyvows.runner.abc import VowsTopicError
 
+from StringIO import StringIO
+
 # These tests check that the reporting, which happens after all tests
 # have run, correctly shows the errors raised in topic functions.
 
@@ -33,7 +35,8 @@ class ErrorReporting(Vows.Context):
             # Patch the print_traceback() method to just record its
             # arguments.
             self.print_traceback_args = None
-            def print_traceback(*args):
+
+            def print_traceback(*args, **kwargs):
                 self.print_traceback_args = args
             self.reporter.print_traceback = print_traceback
 
@@ -53,7 +56,7 @@ class ErrorReporting(Vows.Context):
 
             def reporter_should_call_print_traceback_with_the_exception(self, context):
                 self.parent.print_traceback_args = None
-                self.parent.reporter.print_context('TestContext', context)
+                self.parent.reporter.print_context('TestContext', context, file=StringIO())
                 expect(self.parent.print_traceback_args).to_equal(('type', 'value', 'traceback'))
 
         class ASuccessfulContext:
@@ -71,5 +74,5 @@ class ErrorReporting(Vows.Context):
 
             def reporter_should_not_call_print_traceback(self, context):
                 self.parent.print_traceback_args = None
-                self.parent.reporter.print_context('TestContext', context)
+                self.parent.reporter.print_context('TestContext', context, file=StringIO())
                 expect(self.parent.print_traceback_args).to_equal(None)

--- a/tests/reporting/xunit_reporter_vows.py
+++ b/tests/reporting/xunit_reporter_vows.py
@@ -26,6 +26,7 @@ class XunitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 0
             result.errored_tests = 0
+            result.skipped_tests = 0
             result.total_test_count = 0
             result.elapsed_time = 0
             result.contexts = []
@@ -37,7 +38,7 @@ class XunitReporterVows(Vows.Context):
 
         def should_have_a_testsuite_node(self, topic):
             expect(topic.to_xml()).to_match(r'.*<testsuite errors="0" failures="0" hostname=".+?" ' +
-                                            'name="pyvows" tests="0" time="0\.000" timestamp=".+?"/>')
+                                            'name="pyvows" skip="0" tests="0" time="0\.000" timestamp=".+?"/>')
 
         class WithDocument(Vows.Context):
             def topic(self, topic):
@@ -51,6 +52,7 @@ class XunitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 1
             result.errored_tests = 0
+            result.skipped_tests = 0
             result.total_test_count = 1
             result.elapsed_time = 0
             result.contexts = [
@@ -133,6 +135,7 @@ class XunitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 1
             result.errored_tests = 0
+            result.skipped_tests = 0
             result.total_test_count = 1
             result.elapsed_time = 0
             result.contexts = [
@@ -168,6 +171,7 @@ class XunitReporterVows(Vows.Context):
             result = ResultMock()
             result.successful_tests = 1
             result.errored_tests = 1
+            result.skipped_tests = 0
             result.total_test_count = 2
             result.elapsed_time = 0
             result.contexts = [

--- a/tests/skipping_vows.py
+++ b/tests/skipping_vows.py
@@ -1,0 +1,392 @@
+from pyvows import Vows, expect
+from pyvows.runner import VowsRunner
+from pyvows.runner.executionplan import ExecutionPlanner
+from pyvows.runner import SkipTest
+from pyvows.reporting.test import VowsTestReporter
+from pyvows.reporting.xunit import XUnitReporter
+from pyvows.reporting.common import V_VERBOSE
+
+from StringIO import StringIO
+
+
+@Vows.batch
+class SkippingThings(Vows.Context):
+
+    class ResultsWhenTopicRaisesASkipTestException(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([SkipIsRaisedFromTopic])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            results = runner.run()
+            return results
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        def teardown_is_still_called(self, topic):
+            expect(SkipIsRaisedFromTopic.teardownCalled).to_equal(True)
+
+        def test_is_not_run(self, topic):
+            expect(SkipIsRaisedFromTopic.testRun).to_equal(False)
+
+        def subcontext_topic_is_not_run(self, topic):
+            expect(SkipIsRaisedFromTopic.subcontextTopicRun).to_equal(False)
+
+        def subcontext_test_is_not_run(self, topic):
+            expect(SkipIsRaisedFromTopic.subcontextTestRun).to_equal(False)
+
+        def there_are_four_skipped_tests(self, topic):
+            expect(topic.skipped_tests).to_equal(4)
+
+        def there_are_zero_successful_tests(self, topic):
+            expect(topic.successful_tests).to_equal(0)
+
+        def there_are_zero_errored_tests(self, topic):
+            expect(topic.errored_tests).to_equal(0)
+
+        def there_are_four_total_tests(self, topic):
+            expect(topic.total_test_count).to_equal(4)
+
+        class TestReporterVerbose(Vows.Context):
+            def topic(self, results):
+                return VowsTestReporter(results, V_VERBOSE)
+
+            class TestReporterVerboseOutput(Vows.Context):
+                def topic(self, reporter):
+                    output = StringIO()
+                    reporter.pretty_print(file=output)
+                    return output.getvalue()
+
+                def shows_skipped_count(self, topic):
+                    expect(topic).to_include('4 skipped')
+
+                def top_context_shows_skipped_message(self, topic):
+                    expect(topic).to_include('Skip is raised from topic (SKIPPED: just because)')
+
+                def subcontext_shows_skipped_message(self, topic):
+                    expect(topic).to_include('Sub context (SKIPPED: just because)')
+
+                def tests_should_not_run_vow_shows_skipped(self, topic):
+                    expect(topic).to_include('? tests should not run\n')
+
+                def subcontext_tests_should_also_not_run_vow_shows_skipped(self, topic):
+                    expect(topic).to_include('? subcontext tests should also not run\n')
+
+        class TestReporterNonVerbose(Vows.Context):
+            def topic(self, results):
+                return VowsTestReporter(results, 0)
+
+            class TestReporterNonVerboseOutput(Vows.Context):
+                def topic(self, reporter):
+                    output = StringIO()
+                    reporter.pretty_print(file=output)
+                    return output.getvalue()
+
+                def no_skipped_contexts_or_vows(self, topic):
+                    expect(topic).Not.to_include('SKIPPED')
+                    expect(topic).Not.to_include('?')
+
+        class XunitReporterDocument(Vows.Context):
+            def topic(self, results):
+                return XUnitReporter(results).create_report_document()
+
+            def suite_node_has_attribute_skip_set_to_four(self, topic):
+                expect(topic.firstChild.getAttribute('skip')).to_equal('4')
+
+            class TopContextNode(Vows.Context):
+                def topic(self, doc):
+                    return [testNode for testNode in doc.firstChild.childNodes if testNode.getAttribute('name') == 'topic'][0]
+
+                class TopicSkipNode(Vows.Context):
+                    def topic(self, testcaseNode):
+                        return [node for node in testcaseNode.childNodes if node.nodeName == 'skipped'][0]
+
+                    def message_is_just_because(self, topic):
+                        expect(topic.getAttribute('message')).to_equal('just because')
+
+            class TopContextVowNode(Vows.Context):
+                def topic(self, doc):
+                    return [testNode for testNode in doc.firstChild.childNodes
+                            if testNode.getAttribute('name') == 'tests_should_not_run'][0]
+
+                class VowSkipNode(Vows.Context):
+                    def topic(self, testcaseNode):
+                        return [node for node in testcaseNode.childNodes if node.nodeName == 'skipped'][0]
+
+                    def message_is_just_because(self, topic):
+                        expect(topic.getAttribute('message')).to_equal('just because')
+
+    class ResultsWhenVowsRaiseExceptions(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([SkipIsRaisedFromVow])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            results = runner.run()
+            return results
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        def teardown_is_still_called(self, topic):
+            expect(SkipIsRaisedFromVow.teardownCalled).to_equal(True)
+
+        def subcontext_topic_is_run(self, topic):
+            expect(SkipIsRaisedFromVow.subcontextTopicRun).to_equal(True)
+
+        def there_are_two_skipped_tests(self, topic):
+            expect(topic.skipped_tests).to_equal(2)
+
+        def there_are_two_successful_tests(self, topic):
+            expect(topic.successful_tests).to_equal(2)
+
+        def there_are_zero_errored_tests(self, topic):
+            expect(topic.errored_tests).to_equal(0)
+
+        def there_are_four_total_tests(self, topic):
+            expect(topic.total_test_count).to_equal(4)
+
+        class TestReporterVerbose(Vows.Context):
+            def topic(self, results):
+                return VowsTestReporter(results, V_VERBOSE)
+
+            class TestReporterVerboseOutput(Vows.Context):
+                def topic(self, reporter):
+                    output = StringIO()
+                    reporter.pretty_print(file=output)
+                    return output.getvalue()
+
+                def shows_skipped_count(self, topic):
+                    expect(topic).to_include('2 skipped')
+
+                def top_context_shows_no_skip_message(self, topic):
+                    expect(topic).to_include('Skip is raised from vow\n')
+
+                def subcontext_shows_no_skip_message(self, topic):
+                    expect(topic).to_include('Sub context\n')
+
+                def tests_should_not_run_vow_shows_skipped_with_message(self, topic):
+                    expect(topic).to_include('? tests should not run (SKIPPED: just because)\n')
+
+                def subcontext_tests_should_also_not_run_vow_shows_skipped_with_message(self, topic):
+                    expect(topic).to_include('? subcontext tests should also not run (SKIPPED: just because)\n')
+
+    class ResultsWhenTopicHasSkipIfTrueDecorator(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([TopicHasSkipIfTrueDecorator])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            results = runner.run()
+            return results
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        def teardown_is_still_called(self, topic):
+            expect(TopicHasSkipIfTrueDecorator.teardownCalled).to_equal(True)
+
+        def test_is_not_run(self, topic):
+            expect(TopicHasSkipIfTrueDecorator.testRun).to_equal(False)
+
+        def subcontext_topic_is_not_run(self, topic):
+            expect(TopicHasSkipIfTrueDecorator.subcontextTopicRun).to_equal(False)
+
+        def subcontext_test_is_not_run(self, topic):
+            expect(TopicHasSkipIfTrueDecorator.subcontextTestRun).to_equal(False)
+
+        def there_are_four_skipped_tests(self, topic):
+            expect(topic.skipped_tests).to_equal(4)
+
+        def there_are_zero_successful_tests(self, topic):
+            expect(topic.successful_tests).to_equal(0)
+
+        def there_are_zero_errored_tests(self, topic):
+            expect(topic.errored_tests).to_equal(0)
+
+        def there_are_four_total_tests(self, topic):
+            expect(topic.total_test_count).to_equal(4)
+
+    class ResultsWhenTopicHasSkipDecorator(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([TopicHasSkipDecorator])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            results = runner.run()
+            return results
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        def teardown_is_still_called(self, topic):
+            expect(TopicHasSkipDecorator.teardownCalled).to_equal(True)
+
+        def test_is_not_run(self, topic):
+            expect(TopicHasSkipDecorator.testRun).to_equal(False)
+
+        def subcontext_topic_is_not_run(self, topic):
+            expect(TopicHasSkipDecorator.subcontextTopicRun).to_equal(False)
+
+        def subcontext_test_is_not_run(self, topic):
+            expect(TopicHasSkipDecorator.subcontextTestRun).to_equal(False)
+
+        def there_are_four_skipped_tests(self, topic):
+            expect(topic.skipped_tests).to_equal(4)
+
+        def there_are_zero_successful_tests(self, topic):
+            expect(topic.successful_tests).to_equal(0)
+
+        def there_are_zero_errored_tests(self, topic):
+            expect(topic.errored_tests).to_equal(0)
+
+        def there_are_four_total_tests(self, topic):
+            expect(topic.total_test_count).to_equal(4)
+
+    class ResultsWhenTopicHasSkipIfFalseDecorator(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([TopicHasSkipIfFalseDecorator])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            results = runner.run()
+            return results
+
+        def results_are_successful(self, topic):
+            expect(topic.successful).to_equal(True)
+
+        def teardown_is_still_called(self, topic):
+            expect(TopicHasSkipIfFalseDecorator.teardownCalled).to_equal(True)
+
+        def test_is_not_run(self, topic):
+            expect(TopicHasSkipIfFalseDecorator.testRun).to_equal(True)
+
+        def subcontext_topic_is_not_run(self, topic):
+            expect(TopicHasSkipIfFalseDecorator.subcontextTopicRun).to_equal(True)
+
+        def subcontext_test_is_not_run(self, topic):
+            expect(TopicHasSkipIfFalseDecorator.subcontextTestRun).to_equal(True)
+
+        def there_are_zero_skipped_tests(self, topic):
+            expect(topic.skipped_tests).to_equal(0)
+
+        def there_are_four_successful_tests(self, topic):
+            expect(topic.successful_tests).to_equal(4)
+
+        def there_are_zero_errored_tests(self, topic):
+            expect(topic.errored_tests).to_equal(0)
+
+        def there_are_four_total_tests(self, topic):
+            expect(topic.total_test_count).to_equal(4)
+
+
+class SkipIsRaisedFromTopic(Vows.Context):
+    teardownCalled = False
+    testRun = False
+    subcontextTopicRun = False
+    subcontextTestRun = False
+
+    def topic(self):
+        raise SkipTest('just because')
+
+    def teardown(self):
+        SkipIsRaisedFromTopic.teardownCalled = True
+
+    def tests_should_not_run(self, topic):
+        SkipIsRaisedFromTopic.testRun = True
+
+    class SubContext(Vows.Context):
+        def topic(self):
+            SkipIsRaisedFromTopic.subcontextTopicRun = True
+
+        def subcontext_tests_should_also_not_run(self, topic):
+            SkipIsRaisedFromTopic.subcontextTestRun = True
+
+
+class SkipIsRaisedFromVow(Vows.Context):
+    teardownCalled = False
+    subcontextTopicRun = False
+
+    def topic(self):
+        return 0
+
+    def teardown(self):
+        SkipIsRaisedFromVow.teardownCalled = True
+
+    def tests_should_not_run(self, topic):
+        raise SkipTest('just because')
+
+    class SubContext(Vows.Context):
+        def topic(self):
+            SkipIsRaisedFromVow.subcontextTopicRun = True
+
+        def subcontext_tests_should_also_not_run(self, topic):
+            raise SkipTest('just because')
+
+
+class TopicHasSkipIfTrueDecorator(Vows.Context):
+    teardownCalled = False
+    testRun = False
+    subcontextTopicRun = False
+    subcontextTestRun = False
+
+    @Vows.skip_if(True, 'just because')
+    def topic(self):
+        return 0
+
+    def teardown(self):
+        TopicHasSkipIfTrueDecorator.teardownCalled = True
+
+    def tests_should_not_run(self, topic):
+        TopicHasSkipIfTrueDecorator.testRun = True
+
+    class SubContext(Vows.Context):
+        def topic(self):
+            TopicHasSkipIfTrueDecorator.subcontextTopicRun = True
+
+        def subcontext_tests_should_also_not_run(self, topic):
+            TopicHasSkipIfTrueDecorator.subcontextTestRun = True
+
+
+class TopicHasSkipIfFalseDecorator(Vows.Context):
+    teardownCalled = False
+    testRun = False
+    subcontextTopicRun = False
+    subcontextTestRun = False
+
+    @Vows.skip_if(False, 'just because')
+    def topic(self):
+        return 0
+
+    def teardown(self):
+        TopicHasSkipIfFalseDecorator.teardownCalled = True
+
+    def tests_should_not_run(self, topic):
+        TopicHasSkipIfFalseDecorator.testRun = True
+
+    class SubContext(Vows.Context):
+        def topic(self):
+            TopicHasSkipIfFalseDecorator.subcontextTopicRun = True
+
+        def subcontext_tests_should_also_not_run(self, topic):
+            TopicHasSkipIfFalseDecorator.subcontextTestRun = True
+
+
+class TopicHasSkipDecorator(Vows.Context):
+    teardownCalled = False
+    testRun = False
+    subcontextTopicRun = False
+    subcontextTestRun = False
+
+    @Vows.skip('just because')
+    def topic(self):
+        return 0
+
+    def teardown(self):
+        TopicHasSkipDecorator.teardownCalled = True
+
+    def tests_should_not_run(self, topic):
+        TopicHasSkipDecorator.testRun = True
+
+    class SubContext(Vows.Context):
+        def topic(self):
+            TopicHasSkipDecorator.subcontextTopicRun = True
+
+        def subcontext_tests_should_also_not_run(self, topic):
+            TopicHasSkipDecorator.subcontextTestRun = True


### PR DESCRIPTION
I'm going to start looking into the possibility of skipping tests programmatically similar to other frameworks. I'm thinking of this minimum functionality:
* Can skip running contexts or vows via something like `@Vows.skip(reason)` decorator or `@Vows.skipIf(boolean, reason)`
* Can skip contexts/vows by raising a SkipTest exception
* The `VowsResult` captures skips and the `VowsTestReporter` and `XUnitReporter` both report them
* Skipping a context is the equivalent of skipping each sub-context and each vow of that context

I know with generated topics the decorator will only report 1 skipped context which will be weird but I don't see an easy way around that for now.