### PR TITLE
Fix bug where errors in teardown are unintentionally ignored

### DIFF
--- a/pyvows/runner/gevent.py
+++ b/pyvows/runner/gevent.py
@@ -249,7 +249,10 @@ class VowsParallelRunner(VowsRunnerABC):
                 topic = None
             _run_tests(topic)
             if not ctx_result['error']:
-                _run_teardown()
+                try:
+                    _run_teardown()
+                except Exception, e:
+                    ctx_result['error'] = e
         finally:
             ctx_result['stdout'] = VowsParallelRunner.output.stdout.getvalue()
             ctx_result['stderr'] = VowsParallelRunner.output.stderr.getvalue()

--- a/tests/errors_in_topic_vows.py
+++ b/tests/errors_in_topic_vows.py
@@ -87,6 +87,16 @@ class ErrorsInTopicFunction(Vows.Context):
                 teardownCalled
             ).to_equal(True)
 
+    class WhenTeardownRaisesAnException(Vows.Context):
+        def topic(self):
+            dummySuite = {'dummySuite': set([WhenTeardownRaisesException])}
+            execution_plan = ExecutionPlanner(dummySuite, set(), set()).plan()
+            runner = VowsRunner(dummySuite, Vows.Context, None, None, execution_plan, False)
+            return runner.run()
+
+        def results_are_not_successful(self, topic):
+            expect(topic.successful).to_equal(False)
+
 
 class WhenTopicRaisesAnException(Vows.Context):
     functionsCalled = 0
@@ -124,3 +134,8 @@ class WhenTeardownIsDefined(Vows.Context):
         class WhenTopicRaisesAnException(Vows.Context):
             def topic(self):
                 return 42 / 0
+
+
+class WhenTeardownRaisesException(Vows.Context):
+    def teardown(self):
+        raise Exception('omg')


### PR DESCRIPTION
Return to behavior where teardown exceptions cause the context to fail