### PR TITLE
Add disttools "vows" command

### DIFF
--- a/pyvows/commands.py
+++ b/pyvows/commands.py
@@ -1,0 +1,29 @@
+import subprocess
+import distutils.cmd
+import distutils.log
+
+
+class VowsCommand(distutils.cmd.Command):
+    """Custom command to run pyvows vows"""
+
+    description = 'Run pyvows tests'
+    user_options = [
+        ('pyvows-path=', None, 'Directory or file to search for vows.'),
+        ('pyvows-pattern=', None, 'Pattern for filtering vows files'),
+    ]
+
+    def initialize_options(self):
+        """Set default values for options."""
+        self.pyvows_pattern = '*_vows.py'
+        self.pyvows_path = 'tests/'
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        cmd = 'pyvows -p "{pattern}" {path}'.format(
+            path=self.pyvows_path,
+            pattern=self.pyvows_pattern
+        )
+        self.announce('Executing ' + cmd, level=distutils.log.INFO)
+        subprocess.call(cmd, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools import setup, find_packages
 from pyvows import version
 
 
-
 _test_requires = [
     'argparse',
     'colorama',
@@ -61,7 +60,10 @@ setup(
     entry_points={
         'console_scripts': [
             'pyvows = pyvows.cli:main'
-        ]
+        ],
+        'distutils.commands': [
+            ' vows = pyvows.commands:VowsCommand',
+        ],
     },
 
 


### PR DESCRIPTION
This adds a very basic "vows" command to disttools. It uses all the defaults of the pyvows command and has options to override the path or pattern for the files. This addresses #122

```
$ tree .
.
├── setup.py
├── tests
│   └── some_vows.py
└── tests2
    └── other_stuff.py

2 directories, 3 files

$ cat setup.py
from setuptools import setup
setup(name='testpkg',
      version='1.0',
      setup_requires=['pyvows'])

$ python setup.py install vows
...
running vows
Executing pyvows -p "*_vows.py" tests/

 ============
 Vows Results
 ============

  ✓ OK » 2 honored • 0 broken • 0 skipped (0.000308s)

$ python setup.py install vows --pyvows-path=tests2/ --pyvows-pattern="*.py"
...
running vows
Executing pyvows -p "*.py" tests2/

 ============
 Vows Results
 ============

  ✓ OK » 2 honored • 0 broken • 0 skipped (0.000362s)
```