### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyvows/decorators.py
+++ b/pyvows/decorators.py
@@ -61,7 +61,7 @@ def capture_error(topic_func):
 def skip_if(condition, reason):
     '''Topic or vow or context decorator.  Causes a topic or vow to be skipped if `condition` is True
 
-    This is equivilent to `if condition: raise SkipTest(reason)`
+    This is equivalent to `if condition: raise SkipTest(reason)`
     '''
     from pyvows.core import Vows
 

--- a/pyvows/reporting/test.py
+++ b/pyvows/reporting/test.py
@@ -133,7 +133,7 @@ class VowsTestReporter(VowsReporter):
                 self.indent += 2
 
                 ### NOTE:
-                ###     Commented out try/except; potential debugging hinderance
+                ###     Commented out try/except; potential debugging hindrance
 
                 #try:
 

--- a/pyvows/result.py
+++ b/pyvows/result.py
@@ -27,7 +27,7 @@ class VowsResult(object):
         self.elapsed_time = 0.0
 
     def _count_contexts(self, contexts=None, count_func=lambda context: 1):
-        '''Used interally for class properties
+        '''Used internally for class properties
         `total_test_count`, `successful_tests`, and `errored_tests`.
 
         '''


### PR DESCRIPTION
There are small typos in:
- pyvows/decorators.py
- pyvows/reporting/test.py
- pyvows/result.py

Fixes:
- Should read `internally` rather than `interally`.
- Should read `hindrance` rather than `hinderance`.
- Should read `equivalent` rather than `equivilent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md